### PR TITLE
Rebrand Synapse to Synps

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -16,12 +16,12 @@ const geistMono = Geist_Mono({
 });
 
 export const metadata: Metadata = {
-  title: "Synapse - Live Crypto News & Analytics",
+  title: "Synps - Live Crypto News & Analytics",
   description: "Real-time Web3 news intelligence, trending projects dashboard, seed round discovery, and AI-powered crypto analytics. Stay ahead with live updates every 4 seconds.",
   keywords: ["Web3", "crypto news", "blockchain analytics", "DeFi", "NFT", "crypto intelligence", "trading analytics", "investment discovery"],
   authors: [{ name: "Web3 Intelligence Team" }],
   openGraph: {
-    title: "Synapse - Live Crypto News & Analytics",
+    title: "Synps - Live Crypto News & Analytics",
     description: "Real-time Web3 news intelligence, trending projects dashboard, seed round discovery, and AI-powered crypto analytics. Stay ahead with live updates every 4 seconds.",
     type: "website",
   },

--- a/src/components/enterprise-contact-section.tsx
+++ b/src/components/enterprise-contact-section.tsx
@@ -148,7 +148,7 @@ export function EnterpriseContactSection() {
                   className="mt-1 w-4 h-4 bg-white/5 border border-white/10 rounded focus:ring-2 focus:ring-blue-500"
                 />
                 <label className="text-sm text-gray-300">
-                  I agree to receive marketing communications from Synapse. You can unsubscribe at any time.
+                  I agree to receive marketing communications from Synps. You can unsubscribe at any time.
                 </label>
               </div>
 

--- a/src/components/enterprise-hero-section.tsx
+++ b/src/components/enterprise-hero-section.tsx
@@ -25,7 +25,7 @@ export function EnterpriseHeroSection() {
                 Build smarter.
               </h1>
               <p className="text-xl md:text-2xl text-gray-300 max-w-2xl mx-auto lg:mx-0 leading-relaxed">
-                Synapse helps teams collaborate seamlessly, publish faster, and scale smarter with premium hosting and enterprise-grade security.
+                Synps helps teams collaborate seamlessly, publish faster, and scale smarter with premium hosting and enterprise-grade security.
               </p>
             </div>
 

--- a/src/components/features-section.tsx
+++ b/src/components/features-section.tsx
@@ -50,7 +50,7 @@ export function FeaturesSection() {
         {/* Section Header */}
         <div className="text-center mb-16">
           <h2 className="text-3xl md:text-4xl lg:text-5xl font-bold text-white mb-6">
-            Synapse Platform
+            Synps Platform
           </h2>
           <p className="text-xl text-gray-300 max-w-3xl mx-auto">
             From live news aggregation to AI-powered analytics, get everything you need to stay ahead in the Web3 ecosystem.

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -70,11 +70,11 @@ export function Footer() {
           {/* Brand Section */}
           <div className="lg:col-span-2">
             <Link href="/" className="flex items-center space-x-2 mb-6">
-              <Image src="/logo.png" alt="Synapse" width={32} height={32}/>
-              <span className="text-xl font-bold">Synapse</span>
+              <Image src="/logo.png" alt="Synps" width={32} height={32}/>
+              <span className="text-xl font-bold">Synps</span>
             </Link>
             <p className="text-gray-400 mb-6 max-w-md">
-              Stay ahead in the Web3 - Synapse
+              Stay ahead in the Web3 - Synps
             </p>
             <div className="flex space-x-4">
               <Button 
@@ -117,7 +117,7 @@ export function Footer() {
         {/* Bottom Section */}
         <div className="flex flex-col md:flex-row justify-between items-center space-y-4 md:space-y-0">
           <div className="flex items-center space-x-6">
-            <span className="text-gray-400 text-sm">© 2024 Synapse. All rights reserved.</span>
+            <span className="text-gray-400 text-sm">© 2024 Synps. All rights reserved.</span>
           </div>
           
           <div className="flex items-center space-x-6">

--- a/src/components/hero-section.tsx
+++ b/src/components/hero-section.tsx
@@ -81,11 +81,11 @@ export function HeroSection() {
       <div className="relative z-10 max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
         {/* Main Headline */}
         <div className="mb-8">
-          <Image src="/logo.png" alt="Synapse" width={100} height={100} className="mx-auto mb-6" />
+          <Image src="/logo.png" alt="Synps" width={100} height={100} className="mx-auto mb-6" />
           <h1 className="text-4xl md:text-6xl lg:text-7xl font-bold text-white mb-6 leading-tight">
             Synced with{" "}
             <span className="text-white">
-              Synapse
+              Synps
             </span>
           </h1>
           <p className="text-xl md:text-2xl text-gray-300 max-w-4xl mx-auto leading-relaxed">

--- a/src/components/navigation.tsx
+++ b/src/components/navigation.tsx
@@ -30,8 +30,8 @@ export function Navigation() {
         <div className="flex justify-between items-center h-16">
           {/* Logo */}
           <Link href="/" className="flex items-center space-x-2">
-            <Image src="/logo.png" alt="Synapse" width={32} height={32}/>
-            <span className="text-xl font-bold text-white">Synapse</span>
+            <Image src="/logo.png" alt="Synps" width={32} height={32}/>
+            <span className="text-xl font-bold text-white">Synps</span>
           </Link>
 
           {/* Desktop Menu */}


### PR DESCRIPTION
## Summary
- rename branding from **Synapse** to **Synps** across layout and all components

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869323685f48321819a396289eadc54